### PR TITLE
Add rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,23 @@ Commands:
 
 ## Development
 
+### Testing & Linting
+
+```console
+$ rake
+```
+
 ### Testing
 
 ```console
-$ bundle exec rspec
+$ rake spec
 ```
 
 ### Linting
 
 ```console
-$ bundle exec standardrb
+$ rake standard
+$ rake standard:fix
 ```
 
 ## Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "standard/rake"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: %i[standard spec]


### PR DESCRIPTION
The main advantage here is that `rake` can be used locally to run both the linter and tests and we get easy access to the gem tasks.