### PR TITLE
Add test for invalid gem version

### DIFF
--- a/lib/gemview/commands.rb
+++ b/lib/gemview/commands.rb
@@ -20,8 +20,8 @@ module Gemview
           gem = Gem.find(name: name, version: version)
         rescue Gems::NotFound
           if version
-            warn("Error: No gem found with the name: #{name} and version: #{version}")
-            exit(1) unless TTY::Prompt.new.yes?("Search for the most recent version?")
+            warn("Error: No gem found with the name '#{name}' and the version '#{version}'")
+            exit(1) unless Terminal.confirm(question: "Search for the most recent version?")
             begin
               gem = Gem.find(name: name, version: nil)
             rescue Gems::NotFound

--- a/lib/gemview/terminal.rb
+++ b/lib/gemview/terminal.rb
@@ -2,6 +2,12 @@
 
 module Gemview
   module Terminal
+    # @param question [String]
+    # @return [Boolean]
+    def self.confirm(question:)
+      TTY::Prompt.new.yes?(question)
+    end
+
     # @param content [String]
     def self.page(content)
       TTY::Pager.page(content)

--- a/spec/fixtures/cassettes/find-invalid-rails-gem.yml
+++ b/spec/fixtures/cassettes/find-invalid-rails-gem.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v2/rubygems/rails/versions/250.0.1.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Gems 1.3.0
+      - Ruby
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '32'
+      Content-Type:
+      - text/plain; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Last-Modified:
+      - Thu, 07 Nov 2024 22:30:44 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Security-Policy:
+      - 'default-src ''self''; font-src ''self'' https://fonts.gstatic.com; img-src
+        ''self'' data: https://secure.gaug.es https://gravatar.com https://www.gravatar.com
+        https://secure.gravatar.com https://*.fastly-insights.com https://avatars.githubusercontent.com;
+        object-src ''none''; script-src ''self'' ''sha256-xlpvqdZ5/hVDKsyanT3N+RasZlYKC+bYQ/4furku1bA=''
+        https://secure.gaug.es https://www.fastly-insights.com ''nonce-3a5f0f4adc7c15ad66c1124e4437789a'';
+        style-src ''self'' ''unsafe-inline'' https://fonts.googleapis.com; connect-src
+        ''self'' https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        ''self'' https://github.com/login/oauth/authorize; frame-ancestors ''self'';
+        base-uri ''self''; report-uri https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Aeda971a60e354514c538cbaa1e3d5c1d4503ea1f%2Cenv%3Aproduction%2Ctrace_id%3A2323202271603505827'
+      X-Request-Id:
+      - 7da6c11e-ce12-4020-880c-5f60c74cd64c
+      X-Runtime:
+      - '0.010893'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 52.43.190.113:443
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      Date:
+      - Sun, 08 Dec 2024 22:34:05 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-pao-kpao1770035-PAO
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1733697245.461400,VS0,VE37
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"ad789492742535246fd95343ace99336"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: ASCII-8BIT
+      string: This version could not be found.
+  recorded_at: Sun, 08 Dec 2024 22:34:05 GMT
+recorded_with: VCR 6.3.1

--- a/spec/gemview/__snapshots__/rails-gem-header
+++ b/spec/gemview/__snapshots__/rails-gem-header
@@ -1,0 +1,18 @@
+  [8.0.0] rails
+
+  Ruby on Rails is a full-stack web framework optimized for programmer happiness
+  and sustainable productivity. It encourages beautiful code by favoring
+  convention over configuration.
+  ┌─────────────────┬─────────────────────────────────┐
+  │ Updated at      │ 2024-11-07 22:30:42 UTC         │ 
+  ├─────────────────┼─────────────────────────────────┤
+  │ Total Downloads │ 567,406,953                     │ 
+  ├─────────────────┼─────────────────────────────────┤
+  │ Authors         │ David Heinemeier Hansson        │ 
+  ├─────────────────┼─────────────────────────────────┤
+  │ Licenses        │ [“MIT”]                         │ 
+  ├─────────────────┼─────────────────────────────────┤
+  │ Project URI     │ https://rubygems.org/gems/rails │ 
+  └─────────────────┴─────────────────────────────────┘
+
+More info:

--- a/spec/gemview/commands_spec.rb
+++ b/spec/gemview/commands_spec.rb
@@ -92,6 +92,28 @@ RSpec.describe Gemview::Commands do
         end
       end
     end
+
+    it "falls back to current version" do
+      expect(Gemview::Terminal)
+        .to receive(:confirm)
+        .with(question: "Search for the most recent version?")
+        .and_return(true)
+
+      expect(Gemview::Terminal)
+        .to receive(:choose)
+        .with(
+          message: match_snapshot("rails-gem-header"),
+          choices: %w[Readme Changelog Dependencies Versions]
+        )
+
+      VCR.use_cassette("find-rails-gem") do
+        VCR.use_cassette("find-invalid-rails-gem") do
+          expect { described_class.start(arguments: %w[info rails --version 250.0.1]) }
+            .to output("Error: No gem found with the name 'rails' and the version '250.0.1'\n").to_stderr
+            .and not_output.to_stdout
+        end
+      end
+    end
   end
 
   describe "search" do


### PR DESCRIPTION
This tests the fallback prompt that asks the user if they want to see the gem info for the latest version of the gem if the version they input before was invalid.