### PR TITLE
Workaround TTY::Prompt bug

### DIFF
--- a/lib/gemview/gem.rb
+++ b/lib/gemview/gem.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: true"
 
 module Gemview
   class Gem
@@ -81,9 +81,11 @@ module Gemview
 
     # @return [String]
     def selector_str
+      one_line_info = info.lines.map(&:strip).reject(&:empty?).join(" ").strip
+
       <<~SELECT
         #{name} [#{version}]
-          -- #{Strings.truncate(info.lines.map(&:strip).join(" "), 75)}
+          -- #{Strings.truncate(one_line_info, 75)}
       SELECT
     end
 


### PR DESCRIPTION
I posted a fix for this particular bug around 8 months ago and it hasn't been merged in yet. I've lost all hope and am abandoning the ability to preserve the cursor position in the menu while switching between pages. I've also removed the tildes from the less pager output while I was here.