### PR TITLE
Remove unnecessary autoload

### DIFF
--- a/lib/gemview.rb
+++ b/lib/gemview.rb
@@ -12,7 +12,6 @@ module Gemview
   autoload :GitRepo, "gemview/git_repo"
   autoload :Number, "gemview/number"
   autoload :Terminal, "gemview/terminal"
-  autoload :Version, "gemview/version"
   autoload :View, "gemview/view"
 end
 


### PR DESCRIPTION
This is already required above and the autoload didn't work anyway since the `Gemview::Version` constant doesn't even exist.